### PR TITLE
WIP: Add a new example project for showcasing the presentation styles and options

### DIFF
--- a/Examples/StylesAndOptions/Podfile
+++ b/Examples/StylesAndOptions/Podfile
@@ -1,0 +1,8 @@
+platform :ios, '11.0'
+
+target 'StylesAndOptions' do
+  use_frameworks!
+
+  pod 'PresentationFramework', :path => '../..'
+
+end

--- a/Examples/StylesAndOptions/StylesAndOptions.xcodeproj/project.pbxproj
+++ b/Examples/StylesAndOptions/StylesAndOptions.xcodeproj/project.pbxproj
@@ -1,0 +1,466 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		724601B920D13890000F0BDA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724601B820D13890000F0BDA /* AppDelegate.swift */; };
+		724601C020D13892000F0BDA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 724601BF20D13892000F0BDA /* Assets.xcassets */; };
+		724601C320D13892000F0BDA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724601C120D13892000F0BDA /* LaunchScreen.storyboard */; };
+		724601CE20D13892000F0BDA /* StylesAndOptionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724601CD20D13892000F0BDA /* StylesAndOptionsUITests.swift */; };
+		724601DD20D138DE000F0BDA /* ChooseOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724601D820D138DE000F0BDA /* ChooseOptions.swift */; };
+		724601DE20D138DE000F0BDA /* AppFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724601D920D138DE000F0BDA /* AppFlow.swift */; };
+		724601DF20D138DE000F0BDA /* TableViewControllerUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724601DA20D138DE000F0BDA /* TableViewControllerUtilities.swift */; };
+		724601E020D138DE000F0BDA /* ChooseStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724601DB20D138DE000F0BDA /* ChooseStyle.swift */; };
+		724601E120D138DE000F0BDA /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724601DC20D138DE000F0BDA /* Utilities.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		724601CA20D13892000F0BDA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 724601AD20D13890000F0BDA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 724601B420D13890000F0BDA;
+			remoteInfo = StylesAndOptions;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		724601B520D13890000F0BDA /* StylesAndOptions.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StylesAndOptions.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		724601B820D13890000F0BDA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		724601BF20D13892000F0BDA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		724601C220D13892000F0BDA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		724601C420D13892000F0BDA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		724601C920D13892000F0BDA /* StylesAndOptionsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StylesAndOptionsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		724601CD20D13892000F0BDA /* StylesAndOptionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StylesAndOptionsUITests.swift; sourceTree = "<group>"; };
+		724601CF20D13892000F0BDA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		724601D820D138DE000F0BDA /* ChooseOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChooseOptions.swift; sourceTree = "<group>"; };
+		724601D920D138DE000F0BDA /* AppFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppFlow.swift; sourceTree = "<group>"; };
+		724601DA20D138DE000F0BDA /* TableViewControllerUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewControllerUtilities.swift; sourceTree = "<group>"; };
+		724601DB20D138DE000F0BDA /* ChooseStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChooseStyle.swift; sourceTree = "<group>"; };
+		724601DC20D138DE000F0BDA /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		724601B220D13890000F0BDA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		724601C620D13892000F0BDA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		724601AC20D13890000F0BDA = {
+			isa = PBXGroup;
+			children = (
+				724601B720D13890000F0BDA /* StylesAndOptions */,
+				724601CC20D13892000F0BDA /* StylesAndOptionsUITests */,
+				724601B620D13890000F0BDA /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		724601B620D13890000F0BDA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				724601B520D13890000F0BDA /* StylesAndOptions.app */,
+				724601C920D13892000F0BDA /* StylesAndOptionsUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		724601B720D13890000F0BDA /* StylesAndOptions */ = {
+			isa = PBXGroup;
+			children = (
+				724601B820D13890000F0BDA /* AppDelegate.swift */,
+				724601D920D138DE000F0BDA /* AppFlow.swift */,
+				724601DB20D138DE000F0BDA /* ChooseStyle.swift */,
+				724601D820D138DE000F0BDA /* ChooseOptions.swift */,
+				724601DA20D138DE000F0BDA /* TableViewControllerUtilities.swift */,
+				724601DC20D138DE000F0BDA /* Utilities.swift */,
+				724601BF20D13892000F0BDA /* Assets.xcassets */,
+				724601C120D13892000F0BDA /* LaunchScreen.storyboard */,
+				724601C420D13892000F0BDA /* Info.plist */,
+			);
+			path = StylesAndOptions;
+			sourceTree = "<group>";
+		};
+		724601CC20D13892000F0BDA /* StylesAndOptionsUITests */ = {
+			isa = PBXGroup;
+			children = (
+				724601CD20D13892000F0BDA /* StylesAndOptionsUITests.swift */,
+				724601CF20D13892000F0BDA /* Info.plist */,
+			);
+			path = StylesAndOptionsUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		724601B420D13890000F0BDA /* StylesAndOptions */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 724601D220D13892000F0BDA /* Build configuration list for PBXNativeTarget "StylesAndOptions" */;
+			buildPhases = (
+				724601B120D13890000F0BDA /* Sources */,
+				724601B220D13890000F0BDA /* Frameworks */,
+				724601B320D13890000F0BDA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StylesAndOptions;
+			productName = StylesAndOptions;
+			productReference = 724601B520D13890000F0BDA /* StylesAndOptions.app */;
+			productType = "com.apple.product-type.application";
+		};
+		724601C820D13892000F0BDA /* StylesAndOptionsUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 724601D520D13892000F0BDA /* Build configuration list for PBXNativeTarget "StylesAndOptionsUITests" */;
+			buildPhases = (
+				724601C520D13892000F0BDA /* Sources */,
+				724601C620D13892000F0BDA /* Frameworks */,
+				724601C720D13892000F0BDA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				724601CB20D13892000F0BDA /* PBXTargetDependency */,
+			);
+			name = StylesAndOptionsUITests;
+			productName = StylesAndOptionsUITests;
+			productReference = 724601C920D13892000F0BDA /* StylesAndOptionsUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		724601AD20D13890000F0BDA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0930;
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = iZettle;
+				TargetAttributes = {
+					724601B420D13890000F0BDA = {
+						CreatedOnToolsVersion = 9.3;
+					};
+					724601C820D13892000F0BDA = {
+						CreatedOnToolsVersion = 9.3;
+						TestTargetID = 724601B420D13890000F0BDA;
+					};
+				};
+			};
+			buildConfigurationList = 724601B020D13890000F0BDA /* Build configuration list for PBXProject "StylesAndOptions" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 724601AC20D13890000F0BDA;
+			productRefGroup = 724601B620D13890000F0BDA /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				724601B420D13890000F0BDA /* StylesAndOptions */,
+				724601C820D13892000F0BDA /* StylesAndOptionsUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		724601B320D13890000F0BDA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				724601C320D13892000F0BDA /* LaunchScreen.storyboard in Resources */,
+				724601C020D13892000F0BDA /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		724601C720D13892000F0BDA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		724601B120D13890000F0BDA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				724601E120D138DE000F0BDA /* Utilities.swift in Sources */,
+				724601DF20D138DE000F0BDA /* TableViewControllerUtilities.swift in Sources */,
+				724601E020D138DE000F0BDA /* ChooseStyle.swift in Sources */,
+				724601B920D13890000F0BDA /* AppDelegate.swift in Sources */,
+				724601DE20D138DE000F0BDA /* AppFlow.swift in Sources */,
+				724601DD20D138DE000F0BDA /* ChooseOptions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		724601C520D13892000F0BDA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				724601CE20D13892000F0BDA /* StylesAndOptionsUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		724601CB20D13892000F0BDA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 724601B420D13890000F0BDA /* StylesAndOptions */;
+			targetProxy = 724601CA20D13892000F0BDA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		724601C120D13892000F0BDA /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				724601C220D13892000F0BDA /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		724601D020D13892000F0BDA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		724601D120D13892000F0BDA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		724601D320D13892000F0BDA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = StylesAndOptions/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.izettle.StylesAndOptions;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		724601D420D13892000F0BDA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = StylesAndOptions/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.izettle.StylesAndOptions;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		724601D620D13892000F0BDA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = StylesAndOptionsUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.izettle.StylesAndOptionsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = StylesAndOptions;
+			};
+			name = Debug;
+		};
+		724601D720D13892000F0BDA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = StylesAndOptionsUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.izettle.StylesAndOptionsUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = StylesAndOptions;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		724601B020D13890000F0BDA /* Build configuration list for PBXProject "StylesAndOptions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				724601D020D13892000F0BDA /* Debug */,
+				724601D120D13892000F0BDA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		724601D220D13892000F0BDA /* Build configuration list for PBXNativeTarget "StylesAndOptions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				724601D320D13892000F0BDA /* Debug */,
+				724601D420D13892000F0BDA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		724601D520D13892000F0BDA /* Build configuration list for PBXNativeTarget "StylesAndOptionsUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				724601D620D13892000F0BDA /* Debug */,
+				724601D720D13892000F0BDA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 724601AD20D13890000F0BDA /* Project object */;
+}

--- a/Examples/StylesAndOptions/StylesAndOptions.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/StylesAndOptions/StylesAndOptions.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:StylesAndOptions.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/StylesAndOptions/StylesAndOptions.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/StylesAndOptions/StylesAndOptions.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/StylesAndOptions/StylesAndOptions/AppDelegate.swift
+++ b/Examples/StylesAndOptions/StylesAndOptions/AppDelegate.swift
@@ -1,0 +1,27 @@
+//
+//  AppDelegate.swift
+//  StylesAndOptions
+//
+//  Created by Nataliya Patsovska on 2018-06-05.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import UIKit
+import Flow
+import Presentation
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+    let bag = DisposeBag()
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        bag += window.present(AppFlow())
+
+        return true
+    }
+}
+

--- a/Examples/StylesAndOptions/StylesAndOptions/AppFlow.swift
+++ b/Examples/StylesAndOptions/StylesAndOptions/AppFlow.swift
@@ -1,0 +1,77 @@
+//
+//  AppFlow.swift
+//  StylesAndOptions
+//
+//  Created by Nataliya Patsovska on 2018-06-05.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import UIKit
+import Foundation
+import Flow
+import Presentation
+
+enum ContainerType: String {
+    case navigationController = "UseNavigationContainer"
+    case splitViewController = "UseSplitViewContainer"
+}
+
+struct AppFlow {
+    let containerType: ContainerType
+
+    init() {
+        let arguments = ProcessInfo.processInfo.arguments
+        if arguments.contains(ContainerType.splitViewController.rawValue) {
+            containerType = .splitViewController
+        } else {
+            containerType = .navigationController
+        }
+    }
+}
+
+private extension AppFlow {
+    func createContainer() -> UIViewController {
+
+        switch containerType {
+        case .splitViewController:
+            let split = UISplitViewController()
+            split.preferredDisplayMode = UIDevice.current.userInterfaceIdiom == .pad ? .allVisible : .automatic
+            return split
+        case .navigationController:
+            return UINavigationController()
+        }
+    }
+}
+
+extension AppFlow: Presentable {
+    public func materialize() -> (UIViewController, Disposable) {
+        let bag = DisposeBag()
+
+        let containerController = createContainer()
+        let installDismiss = dismiss(UIBarButtonItem(title: "Cancel"))
+
+        bag += containerController
+            .present(ChooseStyle(), options: [.defaults, .showInMaster])
+            .onValue { style, preferredPresenter, alertToPresent in
+
+                containerController
+                    .present(Presentation(ChoosePresentationOptions(), style: .modal, options: [.defaults, .showInMaster], configure: installDismiss)).future
+                    .onValue { options in
+                        let presentation: EitherPresentation<TapToDismiss, Alert<()>>
+                        if let alertToPresent = alertToPresent {
+                            presentation = .right(Presentation(alertToPresent,
+                                                               style: style,
+                                                               options: options,
+                                                               configure: installDismiss))
+                        } else {
+                            presentation = .left(Presentation(TapToDismiss(),
+                                                              style: style,
+                                                              options: options,
+                                                              configure: style.name == "default" ? { _,_  in } : installDismiss))
+                        }
+                        (preferredPresenter ?? containerController).present(presentation)
+                }
+        }
+        return (containerController, bag)
+    }
+}

--- a/Examples/StylesAndOptions/StylesAndOptions/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/StylesAndOptions/StylesAndOptions/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/StylesAndOptions/StylesAndOptions/Assets.xcassets/Contents.json
+++ b/Examples/StylesAndOptions/StylesAndOptions/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/StylesAndOptions/StylesAndOptions/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/StylesAndOptions/StylesAndOptions/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/StylesAndOptions/StylesAndOptions/ChooseOptions.swift
+++ b/Examples/StylesAndOptions/StylesAndOptions/ChooseOptions.swift
@@ -1,0 +1,59 @@
+//
+//  ChooseOptions.swift
+//  StylesAndOptions
+//
+//  Created by Nataliya Patsovska on 2018-06-12.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import Flow
+import Presentation
+
+struct NamedPresentationOptions {
+    let name: String
+    let value: PresentationOptions
+}
+
+struct ChoosePresentationOptions {
+    private let createDataSource: () -> DataSource<NamedPresentationOptions>
+
+    init() {
+        createDataSource = {
+            let presentationOptions: [(String, PresentationOptions)] = [
+                ("Default", .defaults),
+                ("Embed In Navigation Controller", .embedInNavigationController),
+                ("Dont Wait For Dismiss Animation", .dontWaitForDismissAnimation),
+                ("Unanimated", .unanimated),
+                ("Restore first responder", .restoreFirstResponder),
+
+                ("Show In Master (for split v)", .showInMaster),
+                ("Fail On Block (for modal/popover vc)", .failOnBlock),
+
+                ("Tap Outside To Dismiss (for modal/sheet vc)", .tapOutsideToDismiss),
+
+                ("Disable Push Pop Coalecing (for navigation vc)", .disablePushPopCoalecing),
+                ("Auto Pop (for navigation vc)", .autoPop),
+                ("Auto Pop Successors (for navigation vc)", .autoPopSuccessors),
+                ("Auto Pop Self And Successors (for navigation vc)", .autoPopSelfAndSuccessors),
+                ]
+            return DataSource(options: presentationOptions.map {
+                NamedPresentationOptions(name: $0.0, value: $0.1)
+            })
+        }
+    }
+}
+
+extension ChoosePresentationOptions: Presentable {
+    public func materialize() -> (UIViewController, Signal<PresentationOptions>) {
+        let viewController = UITableViewController()
+        viewController.title = "Presentation Options"
+
+        let result = viewController.configure(dataSource: createDataSource(), delegate: Delegate())
+
+        return (viewController, result.map { $0.value } )
+    }
+}
+
+extension NamedPresentationOptions: CustomStringConvertible {
+    public var description: String { return name }
+}

--- a/Examples/StylesAndOptions/StylesAndOptions/ChooseStyle.swift
+++ b/Examples/StylesAndOptions/StylesAndOptions/ChooseStyle.swift
@@ -1,0 +1,64 @@
+//
+//  ChooseStyle.swift
+//  StylesAndOptions
+//
+//  Created by Nataliya Patsovska on 2018-06-12.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import Flow
+import Presentation
+
+struct ChooseStyle {
+    private let createDataSource: (UIView) -> DataSource<PresentationStyle>
+
+    init() {
+        createDataSource = { view in
+            let styles: [PresentationStyle] = [
+                .default,
+                .modal,
+                .embed(in: view),
+                .invisible,
+                .sheet(from: view, rect: nil),
+                .popover(from: view),
+            ]
+            return DataSource(options: styles)
+        }
+    }
+}
+
+extension ChooseStyle: Presentable {
+    typealias ChooseStyleResult = (PresentationStyle, preferredPresenter: UIViewController?, alertToPresent: Alert<()>?)
+    
+    func materialize() -> (UIViewController, Signal<ChooseStyleResult>) {
+        let viewController = UIViewController()
+        viewController.title = "Presentation Styles"
+
+        let containerForEmbeddingViews = UIView()
+        containerForEmbeddingViews.backgroundColor = .white
+
+        let tableView = UITableView()
+        
+        let content = UIStackView(arrangedSubviews: [tableView, containerForEmbeddingViews])
+        content.distribution = .fillEqually
+        content.axis = .vertical
+
+        viewController.view = content
+
+        let result = tableView.configure(dataSource: createDataSource(containerForEmbeddingViews), delegate: Delegate())
+        return (viewController, result.map { style in
+            if style.name == "embed" {
+                return (style, viewController, nil)
+            } else if style.name == "sheet" {
+                let alertAction = Alert<()>.Action(title: "OK", action: { })
+                return (style, nil, Alert(message: "Test alert", actions: [alertAction]))
+            } else {
+                return (style, nil, nil)
+            }
+        })
+    }
+}
+
+extension PresentationStyle: CustomStringConvertible {
+    public var description: String { return name }
+}

--- a/Examples/StylesAndOptions/StylesAndOptions/Info.plist
+++ b/Examples/StylesAndOptions/StylesAndOptions/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/StylesAndOptions/StylesAndOptions/TableViewControllerUtilities.swift
+++ b/Examples/StylesAndOptions/StylesAndOptions/TableViewControllerUtilities.swift
@@ -1,0 +1,67 @@
+//
+//  TableViewControllerUtilities.swift
+//  StylesAndOptions
+//
+//  Created by Nataliya Patsovska on 2018-06-12.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import Flow
+import UIKit
+
+class DataSource<T: CustomStringConvertible>: NSObject, UITableViewDataSource {
+    let options: [T]
+    private let cellIdentifier = "OptionCell"
+
+    init(options: [T]) {
+        self.options = options
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return options.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier)
+            ?? UITableViewCell(style: .default, reuseIdentifier: cellIdentifier)
+
+        let option = self.option(at: indexPath)
+        cell.textLabel?.text = option.description
+        return cell
+    }
+
+    func option(at indexPath: IndexPath) -> T {
+        return options[indexPath.row]
+    }
+}
+
+class Delegate: NSObject, UITableViewDelegate {
+    let callbacker = Callbacker<IndexPath>()
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        callbacker.callAll(with: indexPath)
+    }
+}
+
+extension UITableViewController {
+    func configure<T>(dataSource: DataSource<T>, delegate: Delegate) -> Signal<T> {
+        return self.tableView.configure(dataSource: dataSource, delegate: delegate)
+    }
+}
+
+extension UITableView {
+    func configure<T>(dataSource: DataSource<T>, delegate: Delegate) -> Signal<T> {
+        self.dataSource = dataSource
+        self.delegate = delegate
+        let selectSignal = Signal(callbacker: delegate.callbacker)
+        let bag = DisposeBag()
+        bag.hold(dataSource, delegate)
+
+        let result = Signal<T> { callback in
+            bag += selectSignal.onValue { callback(dataSource.option(at: $0)) }
+            return bag
+        }
+        return result
+    }
+}

--- a/Examples/StylesAndOptions/StylesAndOptions/Utilities.swift
+++ b/Examples/StylesAndOptions/StylesAndOptions/Utilities.swift
@@ -1,0 +1,36 @@
+//
+//  Utilities.swift
+//  StylesAndOptions
+//
+//  Created by Nataliya Patsovska on 2018-06-13.
+//  Copyright © 2018 iZettle. All rights reserved.
+//
+
+import UIKit
+import Flow
+import Presentation
+
+extension UIBarButtonItem {
+    convenience init(title: String) {
+        self.init()
+        self.title = title
+    }
+}
+
+struct TapToDismiss { }
+
+extension TapToDismiss: Presentable {
+    public func materialize() -> (UIViewController, Future<()>) {
+        let vc = UIViewController()
+        let button = UIButton()
+        button.setTitle("Tap To Dismiss", for: .normal)
+        button.backgroundColor = .blue
+        vc.view = button
+
+        return (vc, Future<()> { completion in
+            return button.onValue {
+                completion(.success)
+            }
+        })
+    }
+}

--- a/Examples/StylesAndOptions/StylesAndOptionsUITests/Info.plist
+++ b/Examples/StylesAndOptions/StylesAndOptionsUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
## In this PR..
I created a new example project with the main goal of adding UI tests to it so that we can test our presentations. It focuses mainly on the styles and options - presenting dummy screens with different combinations of style + options.

It's definitely not covering all combinations since not all of them make sense or are interesting for testing. It might miss some interesting cases though - my idea is to have this project as a starting point and add more cases as we discover them.

## Potential areas for further improvements
- filter the presentation options that make sense for each presentation style
- allow multiple options selection
- cover `DualNavigationControllersSplitDelegate` and `MasterDetailSelection` functionality
- have presentations completing with Signals (currently covering only Futures)

_Do you think I should address any of those before merging?_

## Out of the scope
I intentionally didn't include any extensive tests for our Alerts, I was thinking to add a separate project for that.

_Does this make sense?_

## TODO
- [ ] Check that the projects builds properly with the build script that integrates with CocoaPods
- [ ] Add a build step to execute the UI tests
 