### PR TITLE
Remove Carthage copy phase to avoid iTunes connect invalid Bundle error

### DIFF
--- a/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation.xcodeproj/project.pbxproj
@@ -173,7 +173,6 @@
 				F617E3711C197D5E00B567FB /* Frameworks */,
 				F617E3721C197D5E00B567FB /* Headers */,
 				F617E3731C197D5E00B567FB /* Resources */,
-				B3BF272E20A9BCDE0080ADA2 /* Copy Flow */,
 			);
 			buildRules = (
 			);
@@ -262,22 +261,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		B3BF272E20A9BCDE0080ADA2 /* Copy Flow */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Flow.framework",
-			);
-			name = "Copy Flow";
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Flow.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
 		F6E6FE3820A9C522001CBB2C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
Nested dependencies should not contains this phase, only the main app.

https://github.com/Carthage/Carthage#nested-dependencies

Having this phase leads to the error `Error ITMS-90206 Invalid bundle contains disallowed file 'Frameworks'` when uploading an app to itunes connect