### PR TITLE
Bumped to version 1.2.2 and updated dependency on Flow to be at least…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.2
+
+- Updated dependency on Flow to be at least `>=` instead of compatible with version `~=`.
+
 # 1.2.1
 
 - Remove Carthage copy phase to avoid iTunes connect invalid Bundle error [#10]

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "iZettle/Flow" ~> 1.3
+github "iZettle/Flow" >= 1.3

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.2.1"
+  s.version      = "1.2.2"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { 'iZettle AB' => 'hello@izettle.com' }
 
   s.ios.deployment_target = "9.0"
-  s.dependency 'FlowFramework', '~> 1.3'
+  s.dependency 'FlowFramework', '>= 1.3'
   
   s.source       = { :git => "https://github.com/iZettle/Presentation.git", :tag => "#{s.version}" }
   s.source_files = "Presentation/*.{swift}"


### PR DESCRIPTION
… `>=` instead of compatible with version `~=`.