### PR TITLE
Bugfix: When disposing the bag passed to `present`'s `configure` clos…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.2
+
+- Bugfix: When disposing the bag passed to `present`'s `configure` closure  `present`'s returned future was not completed, hence resulting in the presented view controller being leaked.
+
 # 1.2.1
 
 - Remove Carthage copy phase to avoid iTunes connect invalid Bundle error [#10]

--- a/Presentation/UIViewController+Presentation.swift
+++ b/Presentation/UIViewController+Presentation.swift
@@ -61,8 +61,7 @@ public extension UIViewController {
             bag += {
                 guard !didComplete else { return }
                 log("\(self.presentationDescription) did cancel presentation of: \(vc.presentationDescription)")
-                _ = dismiss()
-                onDismissedBag.dispose()
+                completion(.failure(PresentError.dismissed))
             }
 
             let future = function(vc, bag)


### PR DESCRIPTION
…ure  `present`'s returned future was not completed, hence resulting in the presented view controller being leaked.