### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # 1.3.0
 - Add a static function `prefersNavigationBarHidden(Bool)` to PresentationOptions to return option based on navigation bar  preference passed as a Bool.
-- Update PushPoper implementation in UINavigationController to take additional parameter `vcPrefersNavBarHidden` and respect the preference provided when pushing and popping a `UIViewController`
-- Implement a use-case in `Examples/StylesAndOptions/Example.xcodeproj`
-- Add UI test to secure the new use-case.
+- Implement behaviour to support fallbacks on current client implementations
+- Implement a use-case in `Examples/StylesAndOptions/Example.xcodeproj` and add UI test to secure the new use-case.
 
 # 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.0
+- Add a static function `prefersNavigationBarHidden(Bool)` to PresentationOptions to return option based on navigation bar  preference passed as a Bool.
+- Update PushPoper implementation in UINavigationController to take additional parameter `vcPrefersNavBarHidden` and respect the preference provided when pushing and popping a `UIViewController`
+- Implement a use-case in `Examples/StylesAndOptions/Example.xcodeproj`
+- Add UI test to secure the new use-case.
+
 # 1.2.2
 
 - Bugfix: When disposing the bag passed to `present`'s `configure` closure  `present`'s returned future was not completed, hence resulting in the presented view controller being leaked.

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.2</string>
+	<string>1.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.2.2"
+  s.version      = "1.3.0"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC


### PR DESCRIPTION
- Add a static function `prefersNavigationBarHidden(Bool)` to PresentationOptions to return option based on navigation bar  preference passed as a Bool.
- Update PushPoper implementation in UINavigationController to take additional parameter `vcPrefersNavBarHidden` and respect the preference provided when pushing and popping a `UIViewController`
- Implement a use-case in `Examples/StylesAndOptions/Example.xcodeproj`
- Add UI test to secure the new use-case.