### PR TITLE
Fix PushPoper animations

### DIFF
--- a/Presentation/UINavigationController+Presenting.swift
+++ b/Presentation/UINavigationController+Presenting.swift
@@ -177,9 +177,9 @@ private extension UINavigationController {
             }
         } else {
             // push and pop animations doesn't work for some reason with setViewControllers, so defaulting to pushViewController and popViewController
-            if vcs.count == viewControllers.count + 1 {
+            if vcs.dropLast().elementsEqual(viewControllers) {
                 pushViewController(vcs.last!, animated: animated)
-            } else if vcs.count == viewControllers.count - 1 {
+            } else if vcs.elementsEqual(viewControllers.dropLast()) {
                 popViewController(animated: animated)
             } else {
                 setViewControllers(vcs, animated: animated)

--- a/Presentation/UINavigationController+Presenting.swift
+++ b/Presentation/UINavigationController+Presenting.swift
@@ -176,7 +176,14 @@ private extension UINavigationController {
                 setViewControllers(vcs, animated: animated)
             }
         } else {
-            setViewControllers(vcs, animated: animated)
+            // push and pop animations doesn't work for some reason with setViewControllers, so defaulting to pushViewController and popViewController
+            if vcs.count == viewControllers.count + 1 {
+                pushViewController(vcs.last!, animated: animated)
+            } else if vcs.count == viewControllers.count - 1 {
+                popViewController(animated: animated)
+            } else {
+                setViewControllers(vcs, animated: animated)
+            }
         }
 
         let viewControllerToAppear = vcs.last


### PR DESCRIPTION
I was debugging why the title of a pushed view controller just suddenly pops into it's final position without performing a transition as it should, found out that `setViewControllers(vcs, animated: animated)` was the culprit, so I guess something is flawed inside UIKit.

Not so sure about this fix, but it does fix the animations.

**Before:**

<img src="https://user-images.githubusercontent.com/5459507/50696099-d3dcf200-103e-11e9-90c0-c1d8764ced2d.gif" width="300px" />

**After:**

<img src="https://user-images.githubusercontent.com/5459507/50696115-ddfef080-103e-11e9-9ae9-2fac2e5fe4d9.gif" width="300px" />
 