### PR TITLE
Add "materialize" overload for void result type

### DIFF
--- a/Presentation/Presentable.swift
+++ b/Presentation/Presentable.swift
@@ -53,3 +53,11 @@ public protocol Presentable {
     /// Constructs a matter from `self` and returns it toghether with the result of presenting it.
     func materialize() -> (Matter, Result)
 }
+
+// MARK: - Convinience overloads
+public extension Presentable where Result == Void {
+    func materialize() -> Matter {
+        let result: (Matter, Result) = self.materialize()
+        return result.0
+    }
+}


### PR DESCRIPTION
Small addition to `Presentable` for the cases in which there is no specific result of `materialize`.