### PR TITLE
Change popover's arrow to white

### DIFF
--- a/Presentation/PresentationStyle.swift
+++ b/Presentation/PresentationStyle.swift
@@ -232,12 +232,12 @@ private extension PresentationStyle {
             return from.modallyPresentQueued(vc, options: options) {
                 let popover = vc.popoverPresentationController
                 popover?.permittedArrowDirections = permittedDirections
+                popover?.backgroundColor = .white
 
                 switch source {
                 case .left(let view):
                     popover?.sourceView = view
                     popover?.sourceRect = view.bounds
-                    popover?.backgroundColor = .white
                 case .right(let item):
                     popover?.barButtonItem = item
                 }

--- a/Presentation/PresentationStyle.swift
+++ b/Presentation/PresentationStyle.swift
@@ -237,6 +237,7 @@ private extension PresentationStyle {
                 case .left(let view):
                     popover?.sourceView = view
                     popover?.sourceRect = view.bounds
+                    popover?.backgroundColor = .white
                 case .right(let item):
                     popover?.barButtonItem = item
                 }


### PR DESCRIPTION
### What
This PR makes the popover's background colour white. Currently the view on the popover is white and making the background colour to white as well will update the colour of the arrow.

### Why
Currently it's not very distinguishing where the arrow is when the popover is presented. I've noticed on couple of scenarios in our app:
![bacp](https://user-images.githubusercontent.com/42965221/51248191-ad4c7e80-198f-11e9-8bbc-a5f505d8bde8.png)
![bacop](https://user-images.githubusercontent.com/42965221/51248201-b2113280-198f-11e9-9829-1f46f585a34f.png)

Making the background colour to white it makes it more distinguished! 