### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.0
+- Add support for Signals in Presentation onValue
+- Fix MaterDetailSelection retain cycle
+- Add `materialize` overload for void result type and `materialize(into:)` for disposable result type
+- CI aditions: SwiftLint,CircleCi configs, Xcode 10 project updates
+
 # 1.3.0
 - Add a static function `prefersNavigationBarHidden(Bool)` to PresentationOptions to return option based on navigation bar  preference passed as a Bool.
 - Implement behaviour to support fallbacks on current client implementations

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.3.0"
+  s.version      = "1.4.0"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
- Add support for Signals in Presentation onValue
- Fix MaterDetailSelection retain cycle
- Add `materialize` overload for void result type and `materialize(into:)` for disposable result type
- CI aditions: SwiftLint,CircleCi configs, Xcode 10 project updates