### PR TITLE
Add DEBUG compiler flag in Debug mode

### DIFF
--- a/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation.xcodeproj/project.pbxproj
@@ -464,6 +464,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Presentation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;


### PR DESCRIPTION
The `DEBUG` compiler flag was missing in the framework build settings for Debug mode so the features behind that flag (like memory leak tracking) can't be used when the framework is integrated through Carthage.