### PR TITLE
Disable flaky testNavigationBarVisibilityPreference, issue #36

### DIFF
--- a/Examples/StylesAndOptions/ExampleUITests/ExampleUITests.swift
+++ b/Examples/StylesAndOptions/ExampleUITests/ExampleUITests.swift
@@ -141,7 +141,8 @@ class ExampleUITests: XCTestCase {
         }
     }
 
-    func testNavigationBarVisibilityPreference() {
+    // Issue: https://github.com/iZettle/Presentation/issues/36
+    func disabled_testNavigationBarVisibilityPreference() {
         app.launch()
         showDismissablePresentation(style: "default", option: "NavigationBar visibility preference")
         let navBar = app.navigationBars["UIView"]


### PR DESCRIPTION
As pointed out in other PRs this test is causing problems. It might be a bug in the implementation or the test. To be investigated further: https://github.com/iZettle/Presentation/issues/36

Note: we haven't noticed issues in production where this option is being used but it is also not being used extensively. 
