### PR TITLE
Expose raw presentation events in addition to logs

### DIFF
--- a/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1C0656EB1F8290CB00E60465 /* MemoryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0656EA1F8290CB00E60465 /* MemoryUtils.swift */; };
 		1C0656ED1F8393C100E60465 /* MemoryUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0656EC1F8393C100E60465 /* MemoryUtilsTests.swift */; };
 		2177C8F31D897360000DECA4 /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2177C8F21D897360000DECA4 /* Presentable.swift */; };
+		728711A2229818B700A086DF /* PresentationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728711A1229818B700A086DF /* PresentationEvent.swift */; };
 		F617E3991C197D7600B567FB /* UIViewController+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F617E3981C197D7600B567FB /* UIViewController+Presentation.swift */; };
 		F646BEDB1C85CF5400AA7526 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F646BEDA1C85CF5400AA7526 /* Alert.swift */; };
 		F65D5DC11C58C421002B5D95 /* DualNavigationControllersSplitDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65D5DC01C58C421002B5D95 /* DualNavigationControllersSplitDelegate.swift */; };
@@ -44,6 +45,7 @@
 		1C0656EA1F8290CB00E60465 /* MemoryUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUtils.swift; sourceTree = "<group>"; };
 		1C0656EC1F8393C100E60465 /* MemoryUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUtilsTests.swift; sourceTree = "<group>"; };
 		2177C8F21D897360000DECA4 /* Presentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Presentable.swift; sourceTree = "<group>"; };
+		728711A1229818B700A086DF /* PresentationEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationEvent.swift; sourceTree = "<group>"; };
 		B38092B720A9B718009D8302 /* Flow.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flow.framework; path = Carthage/Build/iOS/Flow.framework; sourceTree = "<group>"; };
 		F617E3751C197D5E00B567FB /* Presentation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Presentation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F617E37A1C197D5E00B567FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				F669340D1E7939E000F83529 /* PresentationOptions.swift */,
 				F617E3981C197D7600B567FB /* UIViewController+Presentation.swift */,
 				F6A2D4971EA9DF3B00C93D9A /* Presentation.swift */,
+				728711A1229818B700A086DF /* PresentationEvent.swift */,
 				F65D5DC61C58C546002B5D95 /* PresentingViewController.swift */,
 				F662929F206911BA00DDE0DF /* UINavigationController+Presenting.swift */,
 				F68A43C71C8047DB0097D483 /* UINavigationController+Signals.swift */,
@@ -312,6 +315,7 @@
 				1C0656EB1F8290CB00E60465 /* MemoryUtils.swift in Sources */,
 				F6B3B6FC1F398E1B00188409 /* KeepSelection.swift in Sources */,
 				F6EA2D251E72D73B0054C302 /* DismissInstallable.swift in Sources */,
+				728711A2229818B700A086DF /* PresentationEvent.swift in Sources */,
 				F66292A0206911BA00DDE0DF /* UISplitViewController+Presenting.swift in Sources */,
 				F666095F1F84C9A0004F2055 /* AssociatedValues.swift in Sources */,
 				F65D5DC71C58C546002B5D95 /* PresentingViewController.swift in Sources */,

--- a/Presentation/MemoryUtils.swift
+++ b/Presentation/MemoryUtils.swift
@@ -28,11 +28,11 @@ extension UIViewController {
         let vcPresentationDescription = vc.presentationDescription
 
         vc.deallocSignal.future.onValue {
-            log("\(vcPresentationDescription) was deallocated after presentation from \(presentationDescription)")
+            log(.didDeallocate(.init(vcPresentationDescription), from: .init(presentationDescription)))
         }
 
         func onLeak() {
-            log("WARNING \(vcPresentationDescription) was NOT deallocated after presentation from \(presentationDescription)")
+            log(.didLeak(.init(vcPresentationDescription), from: .init(presentationDescription)))
 
             guard UserDefaults.standard.bool(forKey: enabledDisplayAlertOnMemoryLeaksKey) else { return }
 

--- a/Presentation/Presentation.swift
+++ b/Presentation/Presentation.swift
@@ -345,18 +345,16 @@ private struct InvisiblePresentable<Result>: Presentable {
     }
 }
 
-private extension Presentable {
-    var debugPresentationTitle: String {
-        return "\(type(of: self))"
-    }
-}
-
 private extension UIViewController {
     func updatePresentationTitle<P: Presentable>(for presentable: P) {
-        let title = presentable.debugPresentationTitle
-        guard !title.hasPrefix("AnyPresentable<") else {
-            return
+        if let presentableIdentifier = (presentable as? PresentableIdentifierExpressible)?.presentableIdentifier {
+            debugPresentationTitle = presentableIdentifier.value
+        } else {
+            let title = "\(type(of: presentable))"
+            guard !title.hasPrefix("AnyPresentable<") else {
+                return
+            }
+            debugPresentationTitle = title
         }
-        debugPresentationTitle = title
     }
 }

--- a/Presentation/PresentationEvent.swift
+++ b/Presentation/PresentationEvent.swift
@@ -1,0 +1,81 @@
+//
+//  PresentationEvent.swift
+//  PresentationFramework
+//
+//  Created by Nataliya Patsovska on 2019-05-24.
+//
+
+import Foundation
+import Flow
+
+/// Events that can be handled by the provided `presentablePresentationEventHandler`
+public enum PresentationEvent {
+    /// Sent when a presentation is blocked by another presentation and will be enqueued for later presentation
+    case willEnqueue(PresentableIdentifier, from: PresentableIdentifier)
+    /// Sent when a presentation is unblocked and will be dequeued for presentation
+    case willDequeue(PresentableIdentifier, from: PresentableIdentifier)
+    /// Sent just before a presentation is presented
+    case willPresent(PresentableIdentifier, from: PresentableIdentifier, styleName: String)
+    /// Sent when a presentation was cancelled and is about to be dismissed
+    case didCancel(PresentableIdentifier, from: PresentableIdentifier)
+    /// Sent when a presentation is dismissed with a type-erased result of the presentation
+    case didDismiss(PresentableIdentifier, from: PresentableIdentifier, result: Result<Any>)
+
+    #if DEBUG
+    case didDeallocate(PresentableIdentifier, from: PresentableIdentifier)
+    case didLeak(PresentableIdentifier, from: PresentableIdentifier)
+    #endif
+}
+
+/// Can be implemented by a Presentable to provide a custom identifier. Defaults to a string representation of the type of the presentable
+public protocol PresentableIdentifierExpressible {
+    var presentableIdentifier: PresentableIdentifier { get }
+}
+
+public struct PresentableIdentifier: ExpressibleByStringLiteral & Equatable & Hashable {
+    public let value: String
+    public init(_ value: String) { self.value = value }
+    public init(stringLiteral value: String) { self.init(value) }
+}
+
+/// Customization point for presentation logging. Defaults to using `print()`
+public var presentableLogPresentation: (_ message: @escaping @autoclosure () -> String, _ data: @escaping @autoclosure () -> String?, _ file: String, _ function: String, _ line: Int) -> () = { (message: () -> String, data: () -> String?, file, function, line) in
+    print("\(file): \(function)(\(line)) - \(message()), data: \(data() ?? "")")
+}
+
+/// Customization point for handing presentation events. Defaults to `presentableLogPresentation` with details for each event type
+public var presentablePresentationEventHandler: (_ event: @escaping @autoclosure () -> PresentationEvent, _ file: String, _ function: String, _ line: Int) -> () = { (event: () -> PresentationEvent, file, function, line) in
+    let presentationEvent = event()
+    let message: String
+    var data: String?
+
+    switch presentationEvent {
+    case let .willEnqueue(presentableId, context):
+        message = "\(context) will enqueue modal presentation of \(presentableId)"
+    case let .willDequeue(presentableId, context):
+        message = "\(context) will dequeue modal presentation of \(presentableId)"
+    case let .willPresent(presentableId, context, styleName):
+        message = "\(context) will '\(styleName)' present: \(presentableId)"
+    case let .didCancel(presentableId, context):
+        message = "\(context) did cancel presentation of: \(presentableId)"
+    case let .didDismiss(presentableId, context, result):
+        switch result {
+        case .success(let result):
+            message = "\(context) did end presentation of: \(presentableId)"
+            data = "\(result)"
+        case .failure(let error):
+            message = "\(context) did end presentation of: \(presentableId)"
+            data = "\(error)"
+        }
+    case let .didDeallocate(presentableId, context):
+        message = "\(presentableId) was deallocated after presentation from \(context)"
+    case let .didLeak(presentableId, context):
+        message = "WARNING \(presentableId) was NOT deallocated after presentation from \(context)"
+    }
+
+    presentableLogPresentation(message, data, file, function, line)
+}
+
+internal func log(_ event: @escaping @autoclosure () -> PresentationEvent, file: String = #file, function: String = #function, line: Int = #line) {
+    presentablePresentationEventHandler(event(), file, function, line)
+}


### PR DESCRIPTION
This is an addition to the existing logging customization point `presentableLogPresentation`. The existing one will continue to work the same way but now an integrator can also provide a `presentablePresentationEventHandler`. This will allow filtering and further analyzing of presentation events on the integrator side because they will no longer come only in a string representation.

I also added a new protocol that can be implemented by Presentables to specify a custom identifier as it is used in the logs.

There can be further improvements in this area. For example we are missing tests and also the docs are not very clear on how the debug title and arguments are being used. I think this can be done later on in a separate PR.