### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.6.0
+- [Bug fix] Add DEBUG compiler flag in Debug mode to enable the debug-only functionality
+- [Addition] Expose raw presentation events in addition to logs
+
+# 1.5.0
+Swift 5 update
+
 # 1.4.1
 - Add `willShowViewControllerSignal` to `UINavigationController` that reflects UINavigationControllerDelegate's `navigationController(_:willShow:animated:)` delegate method.
 

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.4.1"
+  s.version      = "1.6.0"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
- [Bug fix] Add DEBUG compiler flag in Debug mode to enable the debug-only functionality
- [Addition] Expose raw presentation events in addition to logs