### PR TITLE
Pin to a compatible Flow version, not specific one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.1
+- Update Flow dependency and pin it to a compatible version
+
 # 1.6.0
 - [Bug fix] Add DEBUG compiler flag in Debug mode to enable the debug-only functionality
 - [Addition] Expose raw presentation events in addition to logs

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "iZettle/Flow" "1.7.0"
+github "iZettle/Flow" ~> 1.8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "iZettle/Flow" "1.7.0"
+github "iZettle/Flow" "1.8.2"

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Presentation/MemoryUtils.swift
+++ b/Presentation/MemoryUtils.swift
@@ -63,12 +63,6 @@ final class Weak<T> where T: AnyObject {
     init(_ value: T) { self.value = value }
 }
 
-extension NSObject {
-    var deallocSignal: Signal<()> {
-        return associatedValue(forKey: &trackerKey, initial: DeallocTracker()).providedSignal
-    }
-}
-
 extension NSObjectProtocol {
     func trackMemoryLeak(whenDisposed bag: DisposeBag, after: TimeInterval = 2, _ onLeak: @escaping (Self) -> () = { object in assertionFailure("Object Not Deallocated \(object)") }) {
         bag += { [weak self] in
@@ -80,15 +74,4 @@ extension NSObjectProtocol {
     }
 }
 
-private final class DeallocTracker: SignalProvider {
-    let callbacker = Callbacker<()>()
-
-    var providedSignal: Signal<()> {
-        return Signal(callbacker: callbacker)
-    }
-
-    deinit { callbacker.callAll(with: ()) }
-}
-
-private var trackerKey = false
 private var memoryLeakTrackingEnabledKey = false

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.6.0"
+  s.version      = "1.6.1"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Projects using multiple Carthage dependencies that depend on Flow can easily have incompatible requirements if not using this specific version of Flow so pin to anything less than 2.0 instead.