### PR TITLE
Build and test on iOS 12 and 13 in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2
 
 common: &common
-   macos:
-      xcode: "11.0.0"
+  macos:
+    xcode: "11.0.0"
 
 env:
   global:
-  - LC_CTYPE=en_US.UTF-8
-  - LANG=en_US.UTF-8
+    - LC_CTYPE=en_US.UTF-8
+    - LANG=en_US.UTF-8
 
 jobs:
   swiftlint:
@@ -30,6 +30,24 @@ jobs:
             swift -version
             sh build.sh test-iOS
 
+  test-iOS12:
+    macos:
+      xcode:
+        "10.2.0"
+    steps:
+      - checkout
+      - run:
+          name: test iOS
+          command: |
+            set -o pipefail
+            xcodebuild -version
+            xcodebuild -showsdks
+            swift -version
+            IOS_SDK="iphonesimulator12.2" \
+                IOS_DESTINATION_PHONE="OS=12.2,name=iPhone Xs" \
+                sh build.sh test-iOS
+
+
   examples:
     <<: *common
     steps:
@@ -51,7 +69,10 @@ workflows:
       - swiftlint
       - test-iOS:
           requires:
-          - swiftlint
+            - swiftlint
+      - test-iOS12:
+          requires:
+            - swiftlint
       - examples:
           requires:
-          - swiftlint
+            - swiftlint

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,8 @@ set -o pipefail
 PROJECT="Presentation.xcodeproj"
 SCHEME="Presentation"
 
-IOS_SDK="iphonesimulator13.0"
-IOS_DESTINATION_PHONE="OS=13.0,name=iPhone Xs"
+IOS_SDK="${IOS_SDK:-"iphonesimulator13.0"}"
+IOS_DESTINATION_PHONE="${IOS_DESTINATION_PHONE:-"OS=13.0,name=iPhone Xs"}"
 
 usage() {
 cat << EOF


### PR DESCRIPTION
Enable building and running on iOS 12 and 13 in parallel to prevent regressions.