### PR TITLE
Workaround for iOS 13 navigation bar height issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.1
+- [Bug fix] Added a workaround for a navigation bar layout issue in iOS 13. 
+
 # 1.7.0
 - [Big fix] Fix presentation lifecycle management on iOS 13 when swiping down a modal sheet
 - [Addition] Expose a custom adaptive presentation delegate with reactive interface

--- a/Presentation/UINavigationController+Presenting.swift
+++ b/Presentation/UINavigationController+Presenting.swift
@@ -162,7 +162,14 @@ private extension UINavigationController {
 
 
 
-        if let coordinator = transitionCoordinator, !animated {
+        if #available(iOS 13.0, *), viewControllers.isEmpty {
+            // iOS 13 has an issue where the NavBar gets too narrow at initial presentation.
+            // Have tried different approaches to force UIKit to update the navbar layout on the current layout pass, but found no working solution.
+            // See https://github.com/iZettle/Presentation/issues/49
+            DispatchQueue.main.async {
+                self.setViewControllers(vcs, animated: false)
+            }
+        } else if let coordinator = transitionCoordinator, !animated {
             // If we update the vcs while the nc (self) is being presented, the nc gets lost and controls in the the presented vcs can't become first responders.
             // Moving presentation inside transition animate fixes issue.
             let willAnimate = coordinator.animate(alongsideTransition: { _ in


### PR DESCRIPTION
Workaround for this iOS 13 issue: https://github.com/iZettle/Presentation/issues/49

Before:
![NavBar](https://user-images.githubusercontent.com/657370/64525842-13608a00-d302-11e9-887d-7e34e05198d0.png)

After:
![Fixed](https://user-images.githubusercontent.com/657370/64525982-70f4d680-d302-11e9-9568-bee76da30f76.png)
