### PR TITLE
Use the Correct Presentation Fallback Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.1
+- [Bug fix] Fixed a recursive delegate call issue in modal presentstions.
+
 # 1.7.0
 - [Big fix] Fix presentation lifecycle management on iOS 13 when swiping down a modal sheet
 - [Addition] Expose a custom adaptive presentation delegate with reactive interface

--- a/Presentation/CustomAdaptivePresentationDelegate.swift
+++ b/Presentation/CustomAdaptivePresentationDelegate.swift
@@ -47,11 +47,11 @@ public final class CustomAdaptivePresentationDelegate: NSObject, UIAdaptivePrese
 
     // MARK: - UIAdaptivePresentationControllerDelegate
     public func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
-        return adaptivePresentationStyle.call((controller, nil)) ?? controller.adaptivePresentationStyle
+        return adaptivePresentationStyle.call((controller, nil)) ?? controller.presentationStyle
     }
 
     public func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        return adaptivePresentationStyle.call((controller, traitCollection)) ?? controller.adaptivePresentationStyle
+        return adaptivePresentationStyle.call((controller, traitCollection)) ?? controller.presentationStyle
     }
 
     public func presentationController(_ presentationController: UIPresentationController, willPresentWithAdaptiveStyle style: UIModalPresentationStyle, transitionCoordinator: UIViewControllerTransitionCoordinator?) {


### PR DESCRIPTION
Solves this issue: https://github.com/iZettle/Presentation/issues/48

Calling `adaptivePresentationStyle` created a recursive loop, as it uses the `adaptivePresentationStyle(for:)` function as fallback if not set.