### PR TITLE
Remove the Now Redundant Dispatch

### DIFF
--- a/Presentation/UINavigationController+Presenting.swift
+++ b/Presentation/UINavigationController+Presenting.swift
@@ -164,11 +164,8 @@ private extension UINavigationController {
 
         if #available(iOS 13.0, *), viewControllers.isEmpty {
             // iOS 13 has an issue where the NavBar gets too narrow at initial presentation.
-            // Have tried different approaches to force UIKit to update the navbar layout on the current layout pass, but found no working solution.
             // See https://github.com/iZettle/Presentation/issues/49
-            DispatchQueue.main.async {
-                self.setViewControllers(vcs, animated: false)
-            }
+            setViewControllers(vcs, animated: false)
         } else if let coordinator = transitionCoordinator, !animated {
             // If we update the vcs while the nc (self) is being presented, the nc gets lost and controls in the the presented vcs can't become first responders.
             // Moving presentation inside transition animate fixes issue.


### PR DESCRIPTION
Small tweak of the iOS 13 fix from here: https://github.com/iZettle/Presentation/pull/50

With the GM release, the dispatch isn't necessary anymore, but we still need to make sure it won't enter the `transitionCoordinator` path in the `if` statement. I only tried removing the whole workaround when I tried the last PR against GM

The dispatch caused a race condition in the UI tests, but not on all machines (was OK in the previous PR).