### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.7.1
+# 1.8.0
 - [Bug fix] Fixed a recursive delegate call issue in modal presentstions.
 - [Bug fix] Added a workaround for a navigation bar layout issue in iOS 13.
+- [Addition] Added support for Swift Package Manager.
 
 # 1.7.0
 - [Big fix] Fix presentation lifecycle management on iOS 13 when swiping down a modal sheet

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.8.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.7.0"
+  s.version      = "1.8.0"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
- Adds support for Swift Package Manager.
- Fixes a navigation bar layout issue on iOS 13.
- Fixes a bug that could cause the app to get stuck in a recursive loop if the app was presenting a modal while going into the background.