### PR TITLE
Split VC isCollapsed fix (issue 54)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ env:
     - LANG=en_US.UTF-8
 
 jobs:
-  <<: *common
   swiftlint:
+    <<: *common
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.9.0
+- [Addition] Add a new `isCollapsedState` signal to DualNavigationControllersSplitDelegate that has a `nil` value until the collapsed state is known. Old `isCollapsedSignal` is deprecated.
+- [Addition] Add a new `init(collapsedState:)` method to DualNavigationControllersSplitDelegate that takes a future to get notified of a known collapsed state. The `init` without parameters is deprecated.
+- [Change] Deprecate MasterDetailSelection's init with `isCollapsed` signal in favour of init that can handle a `nil` collapsed state
+- [Bug fix] DualNavigationControllersSplitDelegate's `isCollapsedSignal` didn't signal `false` when moving from collapsed state to not collapsed (multitasking/rotation)
+- [Bug fix] DualNavigationControllersSplitDelegate's `isCollapsedSignal` didn't signal anything on iOS 13 ([issue #54](https://github.com/iZettle/Presentation/issues/54))
+
 # 1.8.1
 - [Bug fix] Revert a change of the default SplitVC delegate `isCollapsed` value that doesn't work as expected because it's used before the vc is added to the screen and the value is not reliable
 

--- a/Examples/Messages/Example/Messages.swift
+++ b/Examples/Messages/Example/Messages.swift
@@ -52,7 +52,7 @@ extension Messages: Presentable {
         }
 
         let splitDelegate = split.setupSplitDelegate(ownedBy: bag)
-        let selection = MasterDetailSelection(elements: messages, isSame: ==, isCollapsed: splitDelegate.isCollapsedSignal)
+        let selection = MasterDetailSelection(elements: messages, isSame: ==, collapsedState: splitDelegate.collapsedState)
 
         bag += selectSignal.onValue { indexPath in
             selection.select(index: indexPath.row)

--- a/Examples/Messages/Example/Messages.swift
+++ b/Examples/Messages/Example/Messages.swift
@@ -52,7 +52,7 @@ extension Messages: Presentable {
         }
 
         let splitDelegate = split.setupSplitDelegate(ownedBy: bag)
-        let selection = MasterDetailSelection(elements: messages, isSame: ==, collapsedState: splitDelegate.collapsedState)
+        let selection = MasterDetailSelection(elements: messages, isSame: ==, isCollapsed: splitDelegate.isCollapsed)
 
         bag += selectSignal.onValue { indexPath in
             selection.select(index: indexPath.row)

--- a/Presentation/DualNavigationControllersSplitDelegate.swift
+++ b/Presentation/DualNavigationControllersSplitDelegate.swift
@@ -13,17 +13,17 @@ import Flow
 /// as well as moving view controllers between these while expanding or collapsing.
 open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControllerDelegate {
 
-    @available(*, deprecated, message: "use `init(collapsedState:)` instead")
+    @available(*, deprecated, message: "use `init(isCollapsed:)` instead")
     public convenience override init() {
-        self.init(collapsedState: Future(true))
+        self.init(isCollapsed: Future(true))
     }
 
     /// Creates a delegate that will manage a split view controller with the specified initial collapsed state
-    /// - Parameter collapsedState: Use to report the initial `isCollapsed` state of the split view controller.
+    /// - Parameter isCollapsed: Use to report the initial `isCollapsed` state of the split view controller.
     /// Note that its value can be unreliable until it is rendered on the screen.
-    public init(collapsedState: Future<Bool>) {
+    public init(isCollapsed: Future<Bool>) {
         super.init()
-        initialCollapsedStateDisposable += collapsedState.onValue { [weak self] in
+        initialCollapsedStateDisposable += isCollapsed.onValue { [weak self] in
             self?.isCollapsedProperty.value = $0
         }.disposable
     }
@@ -41,13 +41,13 @@ open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControll
     public let presentDetail = Delegate<UISplitViewController, Disposable>()
 
     /// Returns a signal that will signal when collapsing or expanding with an initial value of true
-    @available(*, deprecated, message: "use `collapsedState` signal instead")
+    @available(*, deprecated, message: "use `isCollapsed` signal instead")
     public var isCollapsedSignal: ReadSignal<Bool> {
-        return isCollapsedProperty.readOnly().map { $0 ?? true }
+        return isCollapsedProperty.map { $0 ?? true }
     }
 
-    /// Returns a signal that will signal when collapsing or expanding. Current value can be nil the collapsed state cannot be determined reliably yet.
-    public var collapsedState: ReadSignal<Bool?> {
+    /// Returns a signal that will signal when collapsing or expanding. Current value can be nil if the collapsed state cannot be determined reliably yet.
+    public var isCollapsed: ReadSignal<Bool?> {
         return isCollapsedProperty.readOnly()
     }
 
@@ -139,7 +139,7 @@ public extension UISplitViewController {
     /// Creates and returns a new split delegate that will be set as `self`'s delegate until `bag` is disposed.
     func setupSplitDelegate(ownedBy bag: DisposeBag) -> DualNavigationControllersSplitDelegate {
         let collapsedState = self.view.didLayoutSignal.map { self.isCollapsed }.future
-        let splitDelegate = DualNavigationControllersSplitDelegate(collapsedState: collapsedState)
+        let splitDelegate = DualNavigationControllersSplitDelegate(isCollapsed: collapsedState)
         delegate = splitDelegate
         bag += {
             _ = splitDelegate

--- a/Presentation/DualNavigationControllersSplitDelegate.swift
+++ b/Presentation/DualNavigationControllersSplitDelegate.swift
@@ -12,8 +12,25 @@ import Flow
 /// A split controller delegate (`UISplitViewControllerDelegate`), that manages navigation controllers for the master and detail view,
 /// as well as moving view controllers between these while expanding or collapsing.
 open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControllerDelegate {
-    private let isCollapsedProperty = ReadWriteSignal(true)
+
+    @available(*, deprecated, message: "use `init(collapsedState:)` instead")
+    public convenience override init() {
+        self.init(collapsedState: Future(true))
+    }
+
+    /// Creates a delegate that will manage a split view controller with the specified initial collapsed state
+    /// - Parameter collapsedState: Use to report the initial `isCollapsed` state of the split view controller.
+    /// Note that its value can be unreliable until it is rendered on the screen.
+    public init(collapsedState: Future<Bool>) {
+        super.init()
+        initialCollapsedStateDisposable += collapsedState.onValue { [weak self] in
+            self?.isCollapsedProperty.value = $0
+        }.disposable
+    }
+
+    private let isCollapsedProperty = ReadWriteSignal<Bool?>(nil)
     private var detailBag: Disposable?
+    private let initialCollapsedStateDisposable = DisposeBag()
 
     /// Customization point for construction of the navigation controllers managed by `self`
     public var makeNavigationController = customNavigationController
@@ -23,8 +40,14 @@ open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControll
 
     public let presentDetail = Delegate<UISplitViewController, Disposable>()
 
-    /// Returns a signal that will signal when collapsing or expanding
+    /// Returns a signal that will signal when collapsing or expanding with an initial value of true
+    @available(*, deprecated, message: "use `collapsedState` signal instead")
     public var isCollapsedSignal: ReadSignal<Bool> {
+        return isCollapsedProperty.readOnly().map { $0 ?? true }
+    }
+
+    /// Returns a signal that will signal when collapsing or expanding. Current value can be nil the collapsed state cannot be determined reliably yet.
+    public var collapsedState: ReadSignal<Bool?> {
         return isCollapsedProperty.readOnly()
     }
 
@@ -39,8 +62,6 @@ open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControll
     }
 
     open func targetDisplayModeForAction(in svc: UISplitViewController) -> UISplitViewController.DisplayMode {
-        isCollapsedProperty.value = svc.isViewLoaded && svc.view.window != nil ? svc.isCollapsed : true
-
         if svc.viewControllers.isEmpty {
             svc.viewControllers.append(makeMasterNavigationController(svc))
         }
@@ -63,6 +84,11 @@ open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControll
     }
 
     open func splitViewController(_ svc: UISplitViewController, collapseSecondary secondaryViewController: UIViewController, onto primaryViewController: UIViewController) -> Bool {
+        defer {
+            initialCollapsedStateDisposable.dispose()
+            isCollapsedProperty.value = true
+        }
+
         guard let primary = primaryViewController as? UINavigationController, let secondary = secondaryViewController as? UINavigationController else {
             detailBag?.dispose()
             return false
@@ -77,12 +103,14 @@ open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControll
             primary.transferViewControllers(from: secondary)
         }
 
-        isCollapsedProperty.value = true
-
         return true
     }
 
     open func splitViewController(_ svc: UISplitViewController, separateSecondaryFrom primaryViewController: UIViewController) -> UIViewController? {
+        defer {
+            initialCollapsedStateDisposable.dispose()
+            isCollapsedProperty.value = false
+        }
         guard let primary = primaryViewController as? UINavigationController else { return nil }
         guard svc.viewControllers.count < 2 else { return svc.viewControllers[1] }
 
@@ -103,8 +131,6 @@ open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControll
             nc.viewControllers = Array(vcs)
         }
 
-        isCollapsedProperty.value = true
-
         return nc
     }
 }
@@ -112,7 +138,8 @@ open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControll
 public extension UISplitViewController {
     /// Creates and returns a new split delegate that will be set as `self`'s delegate until `bag` is disposed.
     func setupSplitDelegate(ownedBy bag: DisposeBag) -> DualNavigationControllersSplitDelegate {
-        let splitDelegate = DualNavigationControllersSplitDelegate()
+        let collapsedState = self.view.didLayoutSignal.map { self.isCollapsed }.future
+        let splitDelegate = DualNavigationControllersSplitDelegate(collapsedState: collapsedState)
         delegate = splitDelegate
         bag += {
             _ = splitDelegate

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.1</string>
+	<string>1.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Presentation/MasterDetailSelection.swift
+++ b/Presentation/MasterDetailSelection.swift
@@ -160,7 +160,10 @@ public extension MasterDetailSelection {
 
             immediate = true
             let presentDisposable = vc.present(presentation.onDismiss {
-                guard let isCollapsed = self.isCollapsed.value else { return }
+                guard let isCollapsed = self.isCollapsed.value else {
+                    assertionFailure("Should not happen because once the collapsed state is determined it should not turn to nil")
+                    return
+                }
                 if isCollapsed && !immediate {
                     self.deselect()
                 }

--- a/Presentation/MasterDetailSelection.swift
+++ b/Presentation/MasterDetailSelection.swift
@@ -21,19 +21,24 @@ public final class MasterDetailSelection<Elements: BidirectionalCollection>: Sig
     private let bag = DisposeBag()
     fileprivate let keepSelection: KeepSelection<Elements>
     private var isSelecting = false
-    fileprivate let isCollapsed: ReadSignal<Bool>
+    fileprivate let isCollapsed: ReadSignal<Bool?>
+
+    @available(*, deprecated, message: "use `init(elements:isSame:needsUpdate:collapsedState:)` instead")
+    public convenience init(elements: ReadSignal<Elements>, isSame: @escaping (Element, Element) -> Bool, needsUpdate: @escaping (Element, Element) -> Bool = { _, _ in false }, isCollapsed: ReadSignal<Bool>) {
+        self.init(elements: elements, isSame: isSame, needsUpdate: needsUpdate, collapsedState: isCollapsed.map { value -> Bool? in return value })
+    }
 
     /// Creates a new instance using changes in `elements` and `isCollapsed` to maintain the selected detail index (provided signal).
     /// - Parameters:
     ///   - isSame: Is it the same row (same identity)
     ///   - needsUpdate: For the same row, does the row have updates that requires presenting new details (refresh details)
     ///   - isCollapsed: Whether or not details are displayed.
-    public init(elements: ReadSignal<Elements>, isSame: @escaping (Element, Element) -> Bool, needsUpdate: @escaping (Element, Element) -> Bool = { _, _ in false }, isCollapsed: ReadSignal<Bool>) {
+    public init(elements: ReadSignal<Elements>, isSame: @escaping (Element, Element) -> Bool, needsUpdate: @escaping (Element, Element) -> Bool = { _, _ in false }, collapsedState: ReadSignal<Bool?>) {
         keepSelection = KeepSelection(elements: elements, isSame: isSame)
-        self.isCollapsed = isCollapsed
+        self.isCollapsed = collapsedState
 
-        bag += isCollapsed.atOnce().onValueDisposePrevious { [weak self] isCollapsed in
-            guard let `self` = self else { return NilDisposer() }
+        bag += collapsedState.atOnce().onValueDisposePrevious { [weak self] isCollapsed in
+            guard let `self` = self, let isCollapsed = isCollapsed else { return NilDisposer() }
             return self.keepSelection.atOnce().enumerate().onValue { [weak self] (eventCount, indexAndElement) in
                 guard let `self` = self else { return }
 
@@ -116,7 +121,7 @@ public final class MasterDetailSelection<Elements: BidirectionalCollection>: Sig
             guard let `self` = self else {
                 return NilDisposer()
             }
-            onSet(self.isCollapsed.value ? nil : self.current)
+            onSet((self.isCollapsed.value == nil || self.isCollapsed.value == true) ? nil: self.current)
             return NilDisposer()
         }
     }()
@@ -145,7 +150,8 @@ public extension MasterDetailSelection {
         var immediate = true
 
         bag += self.presentDetail.set { indexAndElement in
-            guard !self.isCollapsed.value || indexAndElement != nil else {
+            guard let isCollapsed = self.isCollapsed.value else { return }
+            guard !isCollapsed || indexAndElement != nil else {
                 detailBag.dispose()
                 return
             }
@@ -156,7 +162,7 @@ public extension MasterDetailSelection {
 
             immediate = true
             let presentDisposable = vc.present(presentation.onDismiss {
-                if self.isCollapsed.value && !immediate {
+                if isCollapsed && !immediate {
                     self.deselect()
                 }
             }).disposable

--- a/Presentation/UINavigationController+Presenting.swift
+++ b/Presentation/UINavigationController+Presenting.swift
@@ -184,7 +184,7 @@ private extension UINavigationController {
         }
 
         let viewControllerToAppear = vcs.last
-        if let navBarHidden = pushPopers.filter ({ $0.vc == viewControllerToAppear }).last?.vcPrefersNavBarHidden {
+        if let navBarHidden = pushPopers.filter({ $0.vc == viewControllerToAppear }).last?.vcPrefersNavBarHidden {
             self.setNavigationBarHidden(navBarHidden, animated: animated)
         }
 

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.8.1"
+  s.version      = "1.9.0"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.1</string>
+	<string>1.9.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
# 1.9.0
	- [Addition] Add a new `isCollapsedState` signal to DualNavigationControllersSplitDelegate that has a `nil` value until the collapsed state is known. Old `isCollapsedSignal` is deprecated.
	- [Addition] Add a new `init(collapsedState:)` method to DualNavigationControllersSplitDelegate that takes a future to get notified of a known collapsed state. The `init` without parameters is deprecated.
	- [Change] Deprecate MasterDetailSelection's init with `isCollapsed` signal in favour of init that can handle a `nil` collapsed state
	- [Bug fix] DualNavigationControllersSplitDelegate's `isCollapsedSignal` didn't signal `false` when moving from collapsed state to not collapsed (multitasking/rotation)
	- [Bug fix] DualNavigationControllersSplitDelegate's `isCollapsedSignal` didn't signal anything on iOS 13 ([issue #54](https://github.com/iZettle/Presentation/issues/54))


Tested with the Messages app on iOS 11 and 13. Tested in the main iZettle project too. 

