### PR TITLE
Revert is collapsed initial value change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.8.1
+- [Bug fix] Revert a change of the default SplitVC delegate `isCollapsed` value that doesn't work as expected because it's used before the vc is added to the screen and the value is not reliable
+
 # 1.8.0
 - [Bug fix] Fixed a recursive delegate call issue in modal presentstions.
 - [Bug fix] Added a workaround for a navigation bar layout issue in iOS 13.

--- a/Presentation/DualNavigationControllersSplitDelegate.swift
+++ b/Presentation/DualNavigationControllersSplitDelegate.swift
@@ -12,21 +12,7 @@ import Flow
 /// A split controller delegate (`UISplitViewControllerDelegate`), that manages navigation controllers for the master and detail view,
 /// as well as moving view controllers between these while expanding or collapsing.
 open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControllerDelegate {
-
-    @available(*, deprecated, message: "use `init(initialCollapsedState:)` instead")
-    public convenience override init() {
-        self.init(initialCollapsedState: true)
-    }
-
-    /// Creates a delegate that will manage a split view controller with the specified initial collapsed state
-    /// - Parameter initialCollapsedState: The initial state of `isCollapsed` of the managed split view controller
-    ///  so that the delegate can provide correct information through its `isCollapsedSignal`
-    public init(initialCollapsedState: Bool) {
-        isCollapsedProperty = ReadWriteSignal(initialCollapsedState)
-        super.init()
-    }
-
-    private let isCollapsedProperty: ReadWriteSignal<Bool>
+    private let isCollapsedProperty = ReadWriteSignal(true)
     private var detailBag: Disposable?
 
     /// Customization point for construction of the navigation controllers managed by `self`
@@ -126,7 +112,7 @@ open class DualNavigationControllersSplitDelegate: NSObject, UISplitViewControll
 public extension UISplitViewController {
     /// Creates and returns a new split delegate that will be set as `self`'s delegate until `bag` is disposed.
     func setupSplitDelegate(ownedBy bag: DisposeBag) -> DualNavigationControllersSplitDelegate {
-        let splitDelegate = DualNavigationControllersSplitDelegate(initialCollapsedState: isCollapsed)
+        let splitDelegate = DualNavigationControllersSplitDelegate()
         delegate = splitDelegate
         bag += {
             _ = splitDelegate

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.8.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.8.0"
+  s.version      = "1.8.1"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.8.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Revert commit https://github.com/iZettle/Presentation/commit/00660950182583315d8cbe9671c6c3d8d6f13b97 that was not reviewed and tested properly before going to master. That was shipped with 1.8.0 and now we're shipping a patch version just with the revert.