### PR TITLE
Switch to fastlane for build and test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,114 @@
----
-version: 2
+version: 2.1
 
-common: &common
-  macos:
-    xcode: "11.0.0"
+anchors: 
+  - &test_device "iPhone Xs"
+  - &clean_before_build true
+  - &test_output_folder test_output
+  - &default_executor
+    macos:
+      xcode: "11.0.0"
 
 env:
   global:
     - LC_CTYPE=en_US.UTF-8
     - LANG=en_US.UTF-8
 
+commands:
+
+  fetch-pod-specs: # This is a job and not a command to be able to add it as a work flow step
+    steps:
+      - run:
+          name: Fetch CocoaPods Specs
+          command: |
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+
+  pod-install:
+    parameters:
+      path:
+        type: string
+    steps:
+      - fetch-pod-specs
+      - run:
+          command: | 
+            cd <<parameters.path>>
+            pod install --verbose
+
+  carthage-update:
+    steps:
+      - run: carthage update Flow --cache-builds
+
+  test_main_project:
+    steps:
+      - checkout
+      - carthage-update
+      - test_project_and_store_results:
+          project: "Presentation.xcodeproj"
+          scheme: "Presentation"
+
+  test_example_project:
+    parameters:
+      path: # We need to pass a path here because the example projects are in a sub folder of the project
+        type: string
+    steps:
+      - checkout
+      - pod-install:
+          path: <<parameters.path>>
+      - test_workspace_and_store_results:
+          workspace: "Example.xcworkspace"
+          scheme: "Example"
+          path: <<parameters.path>>
+
+  # We introduced two separate commands for projects and workspaces because we didnt find a generic and non-confusing way to introduce 
+  # a condition to only pass either the project or the workspace environment argument to the fastlane scan
+  test_project_and_store_results:
+    description: "Builds and tests a project and then stores the results of the tests as artifacts and test results report"
+    parameters:
+      project:
+        type: string
+      scheme:
+        type: string
+    steps:
+      - run:
+          command: fastlane scan
+          environment:
+              SCAN_PROJECT: <<parameters.project>>
+              SCAN_SCHEME: <<parameters.scheme>>
+              SCAN_DEVICE: *test_device
+              SCAN_CLEAN: *clean_before_build
+      - store_artifacts: # This will by default store an html and junit file as artifacts (See "Artifacts" tab in CircleCI report)
+          path: *test_output_folder # test_output is the default temporary folder for fastlane scan output
+          destination: *test_output_folder # This will create a sub structure in the artifacts section in CircleCI
+      - store_test_results: # This will store the test results so you can then see them in the "Test Summary" tab in CircleCI report
+          path: *test_output_folder
+
+  test_workspace_and_store_results:
+    description: "Builds and tests a workspace and then stores the results of the tests as artifacts and test results report"
+    parameters:
+      workspace:
+        type: string
+      scheme:
+        type: string
+      path:
+        type: string
+    steps:
+      - run:
+          command:  |
+            cd <<parameters.path>>
+            fastlane scan
+          environment:
+              SCAN_WORKSPACE: <<parameters.workspace>>
+              SCAN_SCHEME: <<parameters.scheme>>
+              SCAN_DEVICE: *test_device
+              SCAN_CLEAN: *clean_before_build
+      - store_artifacts: # This will by default store an html and junit file as artifacts (See "Artifacts" tab in CircleCI report)
+          path: *test_output_folder # test_output is the default temporary folder for fastlane scan output
+          destination: *test_output_folder # This will create a sub structure in the artifacts section in CircleCI
+      - store_test_results: # This will store the test results so you can then see them in the "Test Summary" tab in CircleCI report
+          path: *test_output_folder
+
 jobs:
-  swiftlint:
-    <<: *common
+  swiftlint: # This is a job and not a command to be able to add it as a work flow step
+    <<: *default_executor
     steps:
       - checkout
       - run:
@@ -21,60 +117,36 @@ jobs:
             brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/ab64b13d26a3f8617689e3bc7e73a209d11f1bc8/Formula/swiftlint.rb
       - run: swiftlint version && swiftlint --strict
 
-  test-iOS:
-    <<: *common
-    steps:
-      - checkout
-      - run:
-          name: test iOS
-          command: |
-            set -o pipefail
-            xcodebuild -version
-            xcodebuild -showsdks
-            swift -version
-            IOS_SDK="iphonesimulator13.0" \
-                IOS_DESTINATION_PHONE="OS=13.0,name=iPhone 11" \
-                sh build.sh test-iOS
-
-  test-iOS12:
+  test-xcode10-ios12:
     macos:
-      xcode:
-        "10.2.0"
+      xcode: "10.3.0"
     steps:
-      - checkout
-      - run:
-          name: test iOS
-          command: |
-            set -o pipefail
-            xcodebuild -version
-            xcodebuild -showsdks
-            swift -version
-            IOS_SDK="iphonesimulator12.2" \
-                IOS_DESTINATION_PHONE="OS=12.2,name=iPhone Xs" \
-                sh build.sh test-iOS
-
-
-  examples:
-    <<: *common
+      - test_main_project
+      
+  test-xcode11-ios13:
+    <<: *default_executor
     steps:
-      - checkout
-      - run:
-          name: examples
-          command: |
-            set -o pipefail
-            xcodebuild -version
-            xcodebuild -showsdks
-            swift -version
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cfk
-            IOS_SDK="iphonesimulator13.0" \
-                IOS_DESTINATION_PHONE="OS=13.0,name=iPhone 11" \
-                sh build.sh examples
+      - test_main_project
+
+  test-example-messages:
+    <<: *default_executor
+    steps:
+      - test_example_project:
+          path: Examples/Messages
+
+  test-example-styles-and-options:
+    <<: *default_executor
+    steps:
+      - test_example_project:
+          path: Examples/StylesAndOptions
 
 workflows:
-  version: 2
+  version: 2.1
   build-and-test:
     jobs:
       - swiftlint
-      - test-iOS
-      - test-iOS12
-      - examples
+      - test-xcode10-ios12
+      - test-xcode11-ios13
+      - test-example-messages
+      - test-example-styles-and-options
+      


### PR DESCRIPTION
At the moment the CI is done with the help of a shell build script. This appeared to be somewhat cumbersome in the past so here's the PR for switching to fastlane for the build and test.

Instead we now use the direct fastlane scan integration of CircleCI because it has the least boilerplate while still covering all the functionality we need.

Also we changed the workflow a bit so the tests of the example projects now run in parallel. This saves us a lot of time but has one drawback that when you add a new example project you would also need to add a separate job in CircleCI for it. But the process should be quite straight forward and not happen very often. (As we currently have 2 example projects)