### PR TITLE
Fix concurency issue on dissmis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.9.1
+- [Bug fix] Dissmissal happends on worker threads if the result future is mutated by the .succeed() or .fail() methods
+
 # 1.9.0
 - [Addition] Add a new `isCollapsedState` signal to DualNavigationControllersSplitDelegate that has a `nil` value until the collapsed state is known. Old `isCollapsedSignal` is deprecated.
 - [Addition] Add a new `init(collapsedState:)` method to DualNavigationControllersSplitDelegate that takes a future to get notified of a known collapsed state. The `init` without parameters is deprecated.

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "iZettle/Flow" "1.8.2"
+github "iZettle/Flow" "1.8.3"

--- a/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1C0656EB1F8290CB00E60465 /* MemoryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0656EA1F8290CB00E60465 /* MemoryUtils.swift */; };
 		1C0656ED1F8393C100E60465 /* MemoryUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0656EC1F8393C100E60465 /* MemoryUtilsTests.swift */; };
 		2177C8F31D897360000DECA4 /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2177C8F21D897360000DECA4 /* Presentable.swift */; };
+		5B5111792357143500128609 /* FlowIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5111782357143500128609 /* FlowIntegrationTests.swift */; };
 		722FE3B622EA357A00EB04A7 /* CustomAdaptivePresentationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722FE3B522EA357A00EB04A7 /* CustomAdaptivePresentationDelegate.swift */; };
 		728711A2229818B700A086DF /* PresentationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728711A1229818B700A086DF /* PresentationEvent.swift */; };
 		F617E3991C197D7600B567FB /* UIViewController+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F617E3981C197D7600B567FB /* UIViewController+Presentation.swift */; };
@@ -46,6 +47,7 @@
 		1C0656EA1F8290CB00E60465 /* MemoryUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUtils.swift; sourceTree = "<group>"; };
 		1C0656EC1F8393C100E60465 /* MemoryUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUtilsTests.swift; sourceTree = "<group>"; };
 		2177C8F21D897360000DECA4 /* Presentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Presentable.swift; sourceTree = "<group>"; };
+		5B5111782357143500128609 /* FlowIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowIntegrationTests.swift; sourceTree = "<group>"; };
 		722FE3B522EA357A00EB04A7 /* CustomAdaptivePresentationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomAdaptivePresentationDelegate.swift; sourceTree = "<group>"; };
 		728711A1229818B700A086DF /* PresentationEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationEvent.swift; sourceTree = "<group>"; };
 		B38092B720A9B718009D8302 /* Flow.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flow.framework; path = Carthage/Build/iOS/Flow.framework; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				F6B3B74E1F39977000188409 /* MasterDetailSelectionTests.swift */,
 				F6CB32A01F2F399600CA56C2 /* Info.plist */,
 				1C0656EC1F8393C100E60465 /* MemoryUtilsTests.swift */,
+				5B5111782357143500128609 /* FlowIntegrationTests.swift */,
 			);
 			path = PresentationTests;
 			sourceTree = "<group>";
@@ -334,6 +337,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B5111792357143500128609 /* FlowIntegrationTests.swift in Sources */,
 				F6B3B74F1F39977000188409 /* KeepSelectionTests.swift in Sources */,
 				1C0656ED1F8393C100E60465 /* MemoryUtilsTests.swift in Sources */,
 				F6B3B7501F39977000188409 /* MasterDetailSelectionTests.swift in Sources */,

--- a/Presentation.xcodeproj/xcshareddata/xcschemes/Presentation.xcscheme
+++ b/Presentation.xcodeproj/xcshareddata/xcschemes/Presentation.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F617E3741C197D5E00B567FB"
+            BuildableName = "Presentation.framework"
+            BlueprintName = "Presentation"
+            ReferencedContainer = "container:Presentation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F617E3741C197D5E00B567FB"
-            BuildableName = "Presentation.framework"
-            BlueprintName = "Presentation"
-            ReferencedContainer = "container:Presentation.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:Presentation.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.0</string>
+	<string>1.9.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Presentation/UIViewController+Presentation.swift
+++ b/Presentation/UIViewController+Presentation.swift
@@ -16,7 +16,12 @@ public extension UIViewController {
     /// - Note: The returned future will not complete until the dismiss animation completes, unless the `.dontWaitForDismissAnimation` option is provided.
     /// - Note: The presentation can be aborted by cancelling the returned future.
     @discardableResult
-    func present<VC: UIViewController, Value>(_ viewController: VC, style: PresentationStyle = .default, options: PresentationOptions = .defaults, function: @escaping (VC, DisposeBag) -> Future<Value>) -> Future<Value> {
+    func present<VC: UIViewController, Value>(
+        _ viewController: VC,
+        style: PresentationStyle = .default,
+        options: PresentationOptions = .defaults,
+        function: @escaping (VC, DisposeBag) -> Future<Value>
+    ) -> Future<Value> {
         let vc = viewController
         let root = rootViewController
 
@@ -63,9 +68,11 @@ public extension UIViewController {
             }
 
             bag += {
-                guard !didComplete else { return }
-                log(.didCancel(.init(vc.presentationDescription), from: .init(self.presentationDescription)))
-                completion(.failure(PresentError.dismissed))
+                Scheduler.main.async {
+                    guard !didComplete else { return }
+                    log(.didCancel(.init(vc.presentationDescription), from: .init(self.presentationDescription)))
+                    completion(.failure(PresentError.dismissed))
+                }
             }
 
             let future = function(vc, bag)

--- a/PresentationTests/FlowIntegrationTests.swift
+++ b/PresentationTests/FlowIntegrationTests.swift
@@ -1,0 +1,57 @@
+//
+//  RandomTests.swift
+//  PresentationTests
+//
+//  Created by Martin on 2019-10-16.
+//  Copyright © 2019 iZettle. All rights reserved.
+//
+
+import XCTest
+import Flow
+@testable import Presentation
+
+private struct TestPresentable: Presentable {
+    func materialize() -> (UIViewController, Future<Int>) {
+        return (UIViewController(), Future(1).delay(by: 10000))
+    }
+}
+
+class FlowIntegrationTests: XCTestCase {
+
+    let bag = DisposeBag()
+
+    override func tearDown() {
+        bag.dispose()
+        super.tearDown()
+    }
+
+    func testOverrideWithSucessFuture() {
+        let window = UIWindow()
+        window.makeKeyAndVisible()
+        let waitTime: TimeInterval = 2
+        let presenter = UIViewController()
+        window.rootViewController = presenter
+
+        let presented = Presentation(
+            TestPresentable(),
+            style: .modal
+        )
+
+        let e = expectation(description: "Delayed by 2 sec")
+
+        bag += presenter.present(presented)
+            .succeed(with: 2, after: waitTime)
+            .map { String($0) }
+            .onValue {
+                XCTAssertEqual($0, "2")
+                e.fulfill()
+        }
+
+        waitForExpectations(timeout: waitTime + 0.1, handler: { (err) in
+            if let err = err {
+                XCTFail(err.localizedDescription)
+            }
+        })
+    }
+
+}


### PR DESCRIPTION
Moving the solution of this [issue](https://github.com/iZettle/Flow/pull/89) here.

There is a test that illustrates the problem attached to this PR. There where quite a few discussion in the other PR and the conclusion was that this is a Presentation issue and it should be fixed there. 

The main issues is that in `UIViewController+Presentation.swift` there is a disposer that captures the completion block. This disposer gets triggered when the resulting future gets replaced with the `.success()` override and it does not happened on the main thread. This results in 2 issues:
1. There is an arbitrary delay between the presentation and the expected automatic dismiss expected from the `.success()`.
2. The accessor sometimes tries to read the title property and its not always on the main thread.

This fix addresses both