### PR TITLE
When wrapping vc in navigation vc, use vc's modal presentation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.9.2
+- [Bug fix] View controller's modal presentation preferences not used when it's embedded in a navigation controller during presentation.
+
 # 1.9.1
 - [Bug fix] Dissmissal happends on worker threads if the result future is mutated by the .succeed() or .fail() methods
 

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.1</string>
+	<string>1.9.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Presentation/PresentationStyle.swift
+++ b/Presentation/PresentationStyle.swift
@@ -84,17 +84,9 @@ public extension PresentationStyle {
         return PresentationStyle(name: "modally") { viewController, from, options in
             let vc = viewController.embededInNavigationController(options)
 
-            if let presentationStyle = presentationStyle {
-                vc.modalPresentationStyle = presentationStyle
-            }
-
-            if let transitionStyle = transitionStyle {
-                vc.modalTransitionStyle = transitionStyle
-            }
-
-            if let capturesStatusBarAppearance = capturesStatusBarAppearance {
-                vc.modalPresentationCapturesStatusBarAppearance = capturesStatusBarAppearance
-            }
+            vc.modalPresentationStyle = presentationStyle ?? viewController.modalPresentationStyle
+            vc.modalTransitionStyle = transitionStyle ?? viewController.modalTransitionStyle
+            vc.modalPresentationCapturesStatusBarAppearance = capturesStatusBarAppearance ?? viewController.modalPresentationCapturesStatusBarAppearance
 
             return from.modallyPresentQueued(vc, options: options) {
                 Future { completion in

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.9.0"
+  s.version      = "1.9.2"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.0</string>
+	<string>1.9.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
The docs of the static `modally` function say:
> /// Present modally with the option to override `presentationStyle`, `transitionStyle` and `capturesStatusBarAppearance` settings.

This means that if they are not passed and the view controller to be presented have custom `modalPresentationStyle`, `modalTransitionStyle` and `modalPresentationCapturesStatusBarAppearance`, those should be used. Currently that's not the case if the view controller to be presented is wrapped in a navigation controller (which is one of the presentation options).