### PR TITLE
Add a way to use the presentation options in  style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.10.0
+- [Addition] Make it possible to embed a Presentable wrapped in a navigation controller within another view. 
+
 # 1.9.2
 - [Bug fix] View controller's modal presentation preferences not used when it's embedded in a navigation controller during presentation.
 

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.2</string>
+	<string>1.10.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Presentation/PresentationStyle.swift
+++ b/Presentation/PresentationStyle.swift
@@ -180,9 +180,14 @@ public extension PresentationStyle {
     }
 
     /// Present by embedding the view controller in `view`.
-    /// - Parameter dynamicPreferredContentSize: Whether or not the child view controller should automatically update the parents preferredCOntentSize.
-    static func embed(in view: UIView?, dynamicPreferredContentSize: Bool = true) -> PresentationStyle {
-        return PresentationStyle(name: "embed") { vc, from, _ in
+    /// - Parameter dynamicPreferredContentSize: Whether the child view controller should automatically update the parents preferredCOntentSize.
+    /// - Parameter respectPresentationOptions: Whether the mebed of the child view controller will respect the custom presentation options passed during presentation. Defaults to `false` because in most cases embedded view controllers are used in the middle of other views and are not expected to visually look like view controllers, for example to show a navigation bar.
+    ///
+    /// - Note: This presentation style respects the `embedInNavigationController` option.
+    static func embed(in view: UIView?, dynamicPreferredContentSize: Bool = true, respectPresentationOptions: Bool = false) -> PresentationStyle {
+        return PresentationStyle(name: "embed") { viewController, from, options in
+            let vc = options.contains(.embedInNavigationController) ? viewController.embededInNavigationController(options) : viewController
+
             let result = Future<()> { _ in
                 let bag = DisposeBag()
 

--- a/Presentation/PresentationStyle.swift
+++ b/Presentation/PresentationStyle.swift
@@ -186,7 +186,12 @@ public extension PresentationStyle {
     /// - Note: This presentation style respects the `embedInNavigationController` option.
     static func embed(in view: UIView?, dynamicPreferredContentSize: Bool = true, respectPresentationOptions: Bool = false) -> PresentationStyle {
         return PresentationStyle(name: "embed") { viewController, from, options in
-            let vc = options.contains(.embedInNavigationController) ? viewController.embededInNavigationController(options) : viewController
+            let vc: UIViewController
+            if respectPresentationOptions && options.contains(.embedInNavigationController) {
+                vc = viewController.embededInNavigationController(options)
+            } else {
+                vc = viewController
+            }
 
             let result = Future<()> { _ in
                 let bag = DisposeBag()

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.9.2"
+  s.version      = "1.10.0"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.2</string>
+	<string>1.10.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Backwards compatible change that makes it possible to embed a `Presentable` wrapped in a navigation controller within another view. Currently the presentation options for this particular style are ignored.