### PR TITLE
Update for swift 5.2 compatibilety

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ anchors:
   - &test_output_folder test_output
   - &default_executor
     macos:
-      xcode: "11.0.0"
+      xcode: "11.4.0"
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.13.0
+- [Change] Move to Flow version 1.8.4
+- [Bugfix] Fix compile time error in `public extension SignalProvider where Value: Collection {` for swift 5.2
+- [Change] Remove `noTrailingClosure: () = ()` from `init<Result>` for  `Presentation` to avoid `Ambiguous use of 'init' for Signals` compile time errors on call site
+
 # 1.12.0
 - [Addition] Make swipe-to-dismiss blockable through protocol conformance.
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "iZettle/Flow" ~> 1.8.0
+github "iZettle/Flow" "1.8.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "iZettle/Flow" "1.8.3"
+github "iZettle/Flow" "1.8.4"

--- a/Presentation.xcodeproj/project.pbxproj
+++ b/Presentation.xcodeproj/project.pbxproj
@@ -473,6 +473,7 @@
 				INFOPLIST_FILE = Presentation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Presentation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -493,6 +494,7 @@
 				INFOPLIST_FILE = Presentation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.iZettle.Presentation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.12.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Presentation/MasterDetailSelection.swift
+++ b/Presentation/MasterDetailSelection.swift
@@ -203,7 +203,6 @@ public extension MasterDetailSelection {
 
 public extension SignalProvider where Value: BidirectionalCollection {
     /// Returns a signal that will signal when index before `element` is updated.
-    typealias Element = Value.Iterator.Element
     func index(before element: Element, isSame: @escaping (Element, Element) -> Bool) -> CoreSignal<Kind.DropWrite, Value.Index?> {
         return map { collection in
             guard let index = collection.firstIndex(where: { isSame(element, $0) }), index != collection.startIndex else { return nil }
@@ -214,6 +213,7 @@ public extension SignalProvider where Value: BidirectionalCollection {
 
 public extension SignalProvider where Value: Collection {
     /// Returns a signal that will signal when index after `element` is updated.
+    typealias Element = Value.Iterator.Element
     func index(after element: Element, isSame: @escaping (Element, Element) -> Bool) -> CoreSignal<Kind.DropWrite, Value.Index?> {
         return map { collection in
             guard let index = collection.firstIndex(where: { isSame(element, $0) }) else { return nil }

--- a/Presentation/Presentation.swift
+++ b/Presentation/Presentation.swift
@@ -333,7 +333,7 @@ public extension UIWindow {
 
 public extension Presentation {
     /// Creates a new instance with an `.invisible` presentation style where `invisibleResult`'s result is used as result when `self` is being presented.
-    init<Result>(invisibleResult: @escaping () -> Result, _ noTrailingClosure: () = ()) where P == AnyPresentable<UIViewController, Result> {
+    init<Result>(invisibleResult: @escaping () -> Result) where P == AnyPresentable<UIViewController, Result> {
         self.init(InvisiblePresentable(result: invisibleResult), style: .invisible, options: [])
     }
 }

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.12.0"
+  s.version      = "1.13.0"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author       = { 'iZettle AB' => 'hello@izettle.com' }
 
   s.ios.deployment_target = "9.0"
-  s.dependency 'FlowFramework', '>= 1.3'
+  s.dependency 'FlowFramework', '>= 1.8.4'
 
   s.source       = { :git => "https://github.com/iZettle/Presentation.git", :tag => "#{s.version}" }
   s.source_files = "Presentation/*.{swift}"


### PR DESCRIPTION
- [Change] Move to Flow version 1.8.4
- [Bugfix] Fix compile time error in `public extension SignalProvider where Value: Collection {` for swift 5.2
- [Change] Remove `noTrailingClosure: () = ()` from `init<Result>` for  `Presentation` to avoid `Ambiguous use of 'init' for Signals` compile time errors on call site