### PR TITLE
Remove the fatal error in sheet presentation when optional view is not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.13.1
+- [Bug fix] Prevent a crash in sheet presentation style when a source view is not provided. 
+
 # 1.13.0
 - [Change] Move to Flow version 1.8.4
 - [Bugfix] Fix compile time error in `public extension SignalProvider where Value: Collection {` for swift 5.2

--- a/Presentation/Alert.swift
+++ b/Presentation/Alert.swift
@@ -97,10 +97,7 @@ public extension PresentationStyle {
                 disposer = NilDisposer()
             }
 
-            if let presenter = vc.popoverPresentationController {
-                guard let view = sourceView else {
-                    fatalError("Sheet style requires a from view if presented in popover")
-                }
+            if let presenter = vc.popoverPresentationController, let view = sourceView {
                 presenter.sourceView = view
                 presenter.sourceRect = sourceRect ?? view.bounds
             }

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>1.13.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.13.0"
+  s.version      = "1.13.1"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.12.0</string>
+	<string>1.13.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## What?
Removed the fatal error for sheet presentation with non-nil `popoverPresentationController` without a sourceView. Now using the presenting's view controller view as a source view and the source rect is in its center.

Now it works like this with the styles demo app if I change the [sourceView here](https://github.com/iZettle/Presentation/blob/master/Examples/StylesAndOptions/Example/ChooseStyle.swift#L23) to nil:
![Jun-10-2020 14-36-05](https://user-images.githubusercontent.com/60615368/84268785-82d10780-ab28-11ea-942f-fc0da2ddeca3.gif)


## Why?
The example above from the demo app was causing a crash.

The fatal error is redundant and premature.

Redundant because UIKit already crashes with a pretty explanatory message anyway:
<img width="666" alt="Screenshot 2020-06-09 at 09 29 36" src="https://user-images.githubusercontent.com/60615368/84258961-10f0c200-ab18-11ea-895e-28b10303caff.png">

Premature because we're checking the source view at the point of initialisation but it might not be used. For example, on iPad with compact horizontal class (half screen, landscape, multitasking) even though the modalPresentationStyle of an UIAlertController created with preferred style `actionSheet` will be `popover`, the resulting presentation won't be a popover but a bottom sheet. 

I understand that it's better to crash earlier if we know that accessing something at a later point will cause a crash but in this case we don't seem to be getting much from the crash. If we wanted to notify earlier about an API misuse we could make `sourceView` non optional parameter for the presentation style but that will make the API weird as you can show a sheet without a source rect anyway. Thus I'm adding a fallback for the popover anchor location to be the presenting's view centre.
