### PR TITLE
Fix navigation controller root bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.13.3
+- [Bug fix] Fix bug related to presenting a `UINavigationController` modally without an explicit root `UIViewController`, resulting in unexpected behaviour of `UITextField` input cursors.
+
 # 1.13.2
 - Update project settings for Xcode 12 and fix some deprecation warnings
 

--- a/Examples/StylesAndOptions/Example/AppFlow.swift
+++ b/Examples/StylesAndOptions/Example/AppFlow.swift
@@ -63,6 +63,10 @@ extension AppFlow: Presentable {
                 return containerController.present(Presentation(TestNavigationBarHiding(), style: .modal)).toVoid()
             }
 
+            if options.contains(.modalNavigationControllerFlow) {
+                return containerController.present(Presentation(TestNavigationControllerFlow(), style: .modal, configure: withDismiss))
+            }
+
             if options.contains(.allowSwipeDismissAlways) {
                 struct NavigationStack: Presentable {
                     func materialize() -> (UIViewController, Disposable) {

--- a/Examples/StylesAndOptions/Example/ChooseOptions.swift
+++ b/Examples/StylesAndOptions/Example/ChooseOptions.swift
@@ -19,6 +19,7 @@ struct ChoosePresentationOptions { }
 extension PresentationOptions {
     static let navigationBarPreference = PresentationOptions()
     static let showAlertOnDidAttemptToDismiss = PresentationOptions()
+    static let modalNavigationControllerFlow = PresentationOptions()
 }
 
 extension PresentationOptions {
@@ -26,6 +27,7 @@ extension PresentationOptions {
         let presentationOptions: [(String, PresentationOptions)] = [
             ("Default", .defaults),
             ("Embed In Navigation Controller", .embedInNavigationController),
+            ("Modal Navigation Controller flow", .modalNavigationControllerFlow),
             ("Dont Wait For Dismiss Animation", .dontWaitForDismissAnimation),
             ("Unanimated", .unanimated),
             ("Restore first responder", .restoreFirstResponder),

--- a/Examples/StylesAndOptions/Example/NavigationExample.swift
+++ b/Examples/StylesAndOptions/Example/NavigationExample.swift
@@ -12,9 +12,9 @@ import Flow
 
 struct NavigationExample { }
 
-struct TestNavigationBarHiding {
+struct TestNavigationBarHiding { }
 
-}
+struct TestNavigationControllerFlow { }
 
 extension TestNavigationBarHiding: Presentable {
     func materialize() -> (UIViewController, Disposable) {
@@ -49,6 +49,22 @@ extension NavigationExample: Presentable {
             return button.onValue {
                 callback(())
             }
+        })
+    }
+}
+
+extension TestNavigationControllerFlow: Presentable {
+    public func materialize() -> (UIViewController, Future<Void>) {
+        let nc = UINavigationController()
+
+        return (nc, Future { completion in
+            let bag = DisposeBag()
+
+            bag += nc.present(NavigationExample()).onValueDisposePrevious { _ in
+                nc.present(NavigationExample()).onValue { completion(.success)}
+            }
+
+            return bag
         })
     }
 }

--- a/Examples/StylesAndOptions/ExampleUITests/ExampleUITests.swift
+++ b/Examples/StylesAndOptions/ExampleUITests/ExampleUITests.swift
@@ -210,6 +210,27 @@ class ExampleUITests: XCTestCase {
 
         app.terminate()
     }
+
+    func testModalNavigationController() {
+        app.launch()
+
+        let navBar = app.navigationBars["UIView"]
+        let cancelButton = app.buttons["Cancel"]
+        let nextButton = app.buttons["Next"]
+        let backButton = navBar.buttons["Back"]
+
+        chooseStyleAndOption(style: "default", option: "Modal Navigation Controller flow")
+
+        XCTAssertTrue(navBar.exists)
+        cancelButton.waitForExistenceAndTap()
+
+        chooseStyleAndOption(style: "default", option: "Modal Navigation Controller flow")
+
+        nextButton.waitForExistenceAndTap()
+        backButton.waitForExistenceAndTap()
+        nextButton.waitForExistenceAndTap()
+        nextButton.waitForExistenceAndTap()
+    }
     
     // MARK: - Helpers
     func verifyForAllContainerConfigurations(_ verify: () -> ()) {

--- a/Presentation/Info.plist
+++ b/Presentation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.13.2</string>
+	<string>1.13.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Presentation/PresentationStyle.swift
+++ b/Presentation/PresentationStyle.swift
@@ -124,7 +124,7 @@ public extension PresentationStyle {
             bag += viewController.installDismissButton().onValue {
                 completion(.failure(PresentError.dismissed))
             }
-            presented.installDismissButton().onValue {
+            bag += presented.installDismissButton().onValue {
                 completion(.failure(PresentError.dismissed))
             }
 

--- a/Presentation/PresentationStyle.swift
+++ b/Presentation/PresentationStyle.swift
@@ -124,6 +124,9 @@ public extension PresentationStyle {
             bag += viewController.installDismissButton().onValue {
                 completion(.failure(PresentError.dismissed))
             }
+            presented.installDismissButton().onValue {
+                completion(.failure(PresentError.dismissed))
+            }
 
             if viewController.modalPresentationStyle == .popover, let popover = viewController.popoverPresentationController {
                 let delegate = PopoverPresentationControllerDelegate {

--- a/Presentation/PresentationStyle.swift
+++ b/Presentation/PresentationStyle.swift
@@ -121,7 +121,7 @@ public extension PresentationStyle {
                 }
             }
 
-            bag += presented.installDismissButton().onValue {
+            bag += viewController.installDismissButton().onValue {
                 completion(.failure(PresentError.dismissed))
             }
 

--- a/Presentation/UIViewController+Presentation.swift
+++ b/Presentation/UIViewController+Presentation.swift
@@ -28,7 +28,7 @@ public extension UIViewController {
         // iOS 13 temporary fix for issue #40: https://github.com/iZettle/Presentation/issues/40
         let shouldPresentImmediately: Bool
         if #available(iOS 13.0, *) {
-            shouldPresentImmediately = root is UISplitViewController || vc is UISplitViewController || root is UINavigationController
+            shouldPresentImmediately = root is UISplitViewController || vc is UISplitViewController || (root as? UINavigationController)?.viewControllers.isEmpty == true
         } else {
             shouldPresentImmediately = false
         }

--- a/Presentation/UIViewController+Presentation.swift
+++ b/Presentation/UIViewController+Presentation.swift
@@ -28,7 +28,7 @@ public extension UIViewController {
         // iOS 13 temporary fix for issue #40: https://github.com/iZettle/Presentation/issues/40
         let shouldPresentImmediately: Bool
         if #available(iOS 13.0, *) {
-            shouldPresentImmediately = root is UISplitViewController || vc is UISplitViewController
+            shouldPresentImmediately = root is UISplitViewController || vc is UISplitViewController || root is UINavigationController
         } else {
             shouldPresentImmediately = false
         }

--- a/PresentationFramework.podspec
+++ b/PresentationFramework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PresentationFramework"
-  s.version      = "1.13.2"
+  s.version      = "1.13.3"
   s.module_name  = "Presentation"
   s.summary      = "Driving presentations from model to result"
   s.description  = <<-DESC

--- a/PresentationTests/Info.plist
+++ b/PresentationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.13.2</string>
+	<string>1.13.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
This PR fixes a set of subtle problems experienced when a `UINavigationController` is presented in a modal context. The initial presentation wasn't performed immediately, and some kind of lifecycle issue caused input cursors for `UITextField` instances in the first view controller to be missing from the view hierarchy.

The issue could be solved by assigning an explicit root view controller, which lead to the discovery of the problem here in Presentation - likely introduced when creating the workaround for issue #40 in iOS 13+ without considering `UINavigationController`. This PR also fixes a minor issue found when setting up the dismiss action for these flows.